### PR TITLE
Add SNI Support for Server Handshakes

### DIFF
--- a/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/HandshakeWithServer.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/HandshakeWithServer.java
@@ -28,6 +28,6 @@ public class HandshakeWithServer implements ConnectionFlowStep {
   @Override
   public Future execute(ChannelMediator channelMediator, InetSocketAddress remoteAddress) {
     LOG.debug("Starting proxy to server connection handshaking");
-    return channelMediator.handshakeWithServer(_sslContext.createSSLEngine());
+    return channelMediator.handshakeWithServer(_sslContext.createSSLEngine(remoteAddress.getHostName(), 443));
   }
 }


### PR DESCRIPTION
The current implementation of TLS doesn't allow Flashback to hit https servers with Server Name Indication (SNI) enabled, so modify the server handshake logic to account for this.

Jdk 8 may be required for this modified functionality of SSLEngine.