### PR TITLE
only write to channel when it's writable and optimize flushes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build/
 logs/
 .idea/
 */out/*
+*.iml
+*.ipr
+*.iws

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ libs += [
     httpclient: "org.apache.httpcomponents:httpclient:4.3.1",
     jacksonCodec: "com.fasterxml.jackson.core:jackson-core:2.5.3",
     log4j: "log4j:log4j:1.2.17",
-    netty: "io.netty:netty-all:4.0.27.Final",
+    netty: "io.netty:netty-all:4.1.30.Final",
     testng: "org.testng:testng:6.8.8",
     restliServer: "com.linkedin.pegasus:restli-server:6.0.12",
     restliNettyStandalone: "com.linkedin.pegasus:restli-netty-standalone:6.0.12"

--- a/mitm/src/main/java/com/linkedin/mitm/proxy/ProxyInitializer.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/ProxyInitializer.java
@@ -12,6 +12,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 
 
@@ -42,5 +43,6 @@ public class ProxyInitializer extends ChannelInitializer<SocketChannel> {
         new ClientChannelHandler(channelMediator, _proxyServer.getConnectionFlowRegistry());
 
     channelPipeline.addLast("handler", clientChannelHandler);
+    channelPipeline.addFirst(new FlushConsolidationHandler());
   }
 }

--- a/mitm/src/main/java/com/linkedin/mitm/proxy/channel/ClientChannelHandler.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/channel/ClientChannelHandler.java
@@ -58,6 +58,13 @@ public class ClientChannelHandler extends SimpleChannelInboundHandler<HttpObject
   }
 
   @Override
+  public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+    _channelMediator.writeAllToClientIfPossible();
+    _channelMediator.changeReadingFromServerChannel(ctx.channel().isWritable());
+    super.channelWritabilityChanged(ctx);
+  }
+
+  @Override
   public void channelRegistered(ChannelHandlerContext ctx)
       throws Exception {
     _channelMediator.registerChannel(ctx.channel());

--- a/mitm/src/main/java/com/linkedin/mitm/proxy/channel/ServerChannelHandler.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/channel/ServerChannelHandler.java
@@ -12,6 +12,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpObject;
 import org.apache.log4j.Logger;
 
+
 /**
  * Server channel handler that implemented read logic from server side.
  * Note: It's stateful. Each {@link com.linkedin.mitm.proxy.channel.ClientChannelHandler} map to one
@@ -30,7 +31,7 @@ public class ServerChannelHandler extends SimpleChannelInboundHandler<HttpObject
   }
 
   @Override
-  protected void channelRead0(ChannelHandlerContext channelHandlerContext, HttpObject httpObject)
+  protected void channelRead0(ChannelHandlerContext ctx, HttpObject httpObject)
       throws Exception {
     _channelMediator.readFromServerChannel(httpObject);
     if (httpObject instanceof DefaultLastHttpContent) {
@@ -46,6 +47,13 @@ public class ServerChannelHandler extends SimpleChannelInboundHandler<HttpObject
     _channelMediator.registerChannel(ctx.channel());
     LOG.debug("server channel registered" + ctx.channel());
     super.channelRegistered(ctx);
+  }
+
+  @Override
+  public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+    _channelMediator.writeAllToServerIfPossible();
+    _channelMediator.changeReadingFromClientChannel(ctx.channel().isWritable());
+    super.channelWritabilityChanged(ctx);
   }
 
   @Override

--- a/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/ResumeReadingFromClient.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/ResumeReadingFromClient.java
@@ -23,6 +23,6 @@ public class ResumeReadingFromClient implements ConnectionFlowStep {
   @Override
   public Future execute(ChannelMediator channelMediator, InetSocketAddress remoteAddress) {
     LOG.debug("Resume reading from client");
-    return channelMediator.resumeReadingFromClientChannel();
+    return channelMediator.changeReadingFromClientChannel(true);
   }
 }

--- a/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/StopReadingFromClient.java
+++ b/mitm/src/main/java/com/linkedin/mitm/proxy/connectionflow/steps/StopReadingFromClient.java
@@ -23,6 +23,6 @@ public class StopReadingFromClient implements ConnectionFlowStep {
   @Override
   public Future execute(ChannelMediator channelMediator, InetSocketAddress remoteAddress) {
     LOG.info("Stop reading from client");
-    return channelMediator.stopReadingFromClientChannel();
+    return channelMediator.changeReadingFromClientChannel(false);
   }
 }


### PR DESCRIPTION
Summary:
1. Check channel's writability before writing more bytes to it.
2. Add FlushConsolidationHandler to optimize socket flushes which are expensive OS calls.

Currently we are writing to either server or client channel without first checking if the channel is writable. This can cause problems if we end up writing too fast. To improve on this, we need to check channel.isWritable before each write, and when the channel's writability changes to false, pause reading from the source channel.

We are also calling writeAndFlush for every payload that's read from the client or server (e.g., an http request is dissected into several payloads: HttpRequest, 1 or more HttpContent). The flush results in a syscall at the OS level and is usually expensive. We can optimize these calls by adding a FlushConsolidationHandler which is provided by netty in a recent minor version. This handler tries to batch multiple flushes (up to 256) into a single flush.