### PR TITLE
publishing to JFrog Bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build/
 logs/
 .idea/
 */out/*
+*.iml
+*.ipr
+*.iws

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-BSD 2-CLAUSE LICENSE
+BSD 2-Clause License
 
-Copyright 2016 LinkedIn Corporation.
+Copyright 2016, LinkedIn Corporation.
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/build.gradle
+++ b/build.gradle
@@ -1,31 +1,25 @@
 if (project.hasProperty('overrideBuildEnvironment')) {
-  //The property is automatically passed to the Gradle build when the project is built at LinkedIn
-  //The property contains the file path to a script plugin that 'adapts' this OS project to LinkedIn
-  //In order to adapt the project, we need to apply this script plugin:
+  // Otherwise, assume overrideBuildEnvironment defines a path to a file, and apply it.
   apply from: project.overrideBuildEnvironment
 }
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.13'
+  gradleVersion = '6.4'
 }
-
-
 
 buildscript {
   repositories {
     mavenCentral()
     mavenLocal()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
   }
 }
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
-
-
-buildscript {
-  repositories {
-    mavenCentral()
-    mavenLocal()
-  }
-}
 
 ext {
   libs = [:]
@@ -49,7 +43,12 @@ libs += [
 ]
 
 allprojects {
-  apply plugin: "java"
+  version='0.0.5'
+  group='com.linkedin.flashback'
+
+  apply plugin: 'maven'
+  apply plugin: 'maven-publish'
+  apply plugin: 'java'
   apply plugin: 'idea'
 
   dependencies {
@@ -126,3 +125,76 @@ project(':flashback-admin') {
   }
 }
 
+project(':flashback-all') {
+  dependencies {
+    // this is a meta project that depends on all of the "entry-point" subprojects to make it easier to pull in the
+    // entire dependency tree.
+    compile project(':flashback-core-impl')
+    compile project(':mitm')
+    compile project(':flashback-test-util')
+    compile project(':flashback-smartproxy')
+    compile project(':flashback-netty')
+    compile project(':flashback-admin')
+  }
+}
+
+
+tasks.withType(Jar) {
+  from "$rootDir/LICENSE"
+  from "$rootDir/NOTICE"
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+  classifier = 'sources'
+  from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from javadoc.destinationDir
+}
+
+def pomConfig = {
+  licenses {
+    license {
+      name "2-CLAUSE BSD"
+      url "https://github.com/linkedin/flashback/blob/master/LICENSE"
+      distribution "repo"
+    }
+  }
+
+  scm {
+    url 'https://github.com/linkedin/flashback.git'
+
+  }
+}
+
+
+publishing {
+  publications {
+    MyPublication(MavenPublication) {
+      from components.java
+      artifact javadocJar
+      artifact sourcesJar
+
+      pom.withXml {
+        def root = asNode()
+        root.appendNode('name', 'flashback')
+        root.children().last() + pomConfig
+      }
+    }
+  }
+}
+
+bintray {
+  user = System.getenv('BINTRAY_USER')
+  key = System.getenv('BINTRAY_API_KEY')
+  publications = ['MyPublication']
+  pkg {
+    repo = 'maven'
+    userOrg = 'linkedin'
+    name = 'flashback'
+
+    vcsUrl = 'https://github.com/linkedin/flashback.git'
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
-include 'flashback-core-impl', 'flashback-netty', 'flashback-smartproxy', 'flashback-test-util', 'mitm', 'flashback-admin'
+include 'flashback-core-impl',
+        'flashback-netty',
+        'flashback-smartproxy',
+        'flashback-test-util',
+        'mitm',
+        'flashback-admin',
+        'flashback-all'


### PR DESCRIPTION
-Followed instruction **https://github.com/bintray/gradle-bintray-plugin** to publish flashback Bintray 
-Add an "flashback-all" subproject that makes it easier to depend on the
entirety of flashback.
-Minor cleanup

Testing:
publish locally:

`./gradlew -Dmaven.repo.local=$HOME/local-repo assemble publishToMavenLocal`
checked pom:
`<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.linkedin.flashback</groupId>
  <artifactId>flashback</artifactId>
  <version>0.0.5</version>
  <dependencies>
    <dependency>
      <groupId>org.apache.commons</groupId>
      <artifactId>commons-lang3</artifactId>
      <version>3.4</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>commons-io</groupId>
      <artifactId>commons-io</artifactId>
      <version>2.4</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcpkix-jdk15on</artifactId>
      <version>1.51</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcprov-jdk15on</artifactId>
      <version>1.51</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>commons-cli</groupId>
      <artifactId>commons-cli</artifactId>
      <version>1.2</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.easymock</groupId>
      <artifactId>easymock</artifactId>
      <version>3.3</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>18.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpclient</artifactId>
      <version>4.3.1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-core</artifactId>
      <version>2.5.3</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>log4j</groupId>
      <artifactId>log4j</artifactId>
      <version>1.2.17</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-all</artifactId>
      <version>4.0.27.Final</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
  <name>flashback</name>
  <licenses>
    <license>
      <name>2-CLAUSE BSD</name>
      <url>https://github.com/linkedin/flashback/blob/master/LICENSE</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <scm>
    <url>https://github.com/linkedin/flashback.git</url>
  </scm>
</project>`